### PR TITLE
'Null object cannot be converted to a value type.' error fixed 

### DIFF
--- a/BatMap.Tests/ConfigurationTests.cs
+++ b/BatMap.Tests/ConfigurationTests.cs
@@ -332,5 +332,17 @@ namespace BatMap.Tests {
             Assert.Equal(42, dto.Id);
             Assert.Equal("Zaphod", dto.Name);
         }
+
+        [Fact]
+        public void Map_Nullable_Conversation_When_Value_Null() {
+            var config = new MapConfiguration();
+            config.RegisterMap<ForTest9, ForTest9DTO>();
+
+            var model = new ForTest9();
+            var dto = config.Map<ForTest9, ForTest9DTO>(model);
+
+            Assert.Equal(dto.Amount, null);
+        }
+
     }
 }

--- a/BatMap.Tests/DTO/ForTestDTO.cs
+++ b/BatMap.Tests/DTO/ForTestDTO.cs
@@ -46,4 +46,8 @@ namespace BatMap.Tests.DTO {
         public int Id { get; }
         public string Name { get; }
     }
+
+    public class ForTest9DTO{
+        public decimal? Amount { get; set; }
+    }
 }

--- a/BatMap.Tests/Model/ForTest.cs
+++ b/BatMap.Tests/Model/ForTest.cs
@@ -46,4 +46,8 @@ namespace BatMap.Tests.Model {
         public int Id { get; }
         public string Name { get; }
     }
+
+    public class ForTest9 {
+        public double? Amount { get; set; }
+    }
 }

--- a/BatMap/ExpressionProvider.cs
+++ b/BatMap/ExpressionProvider.cs
@@ -61,7 +61,7 @@ namespace BatMap {
             if (inMember.IsPrimitive) {
                 Expression member = Expression.PropertyOrField(inObjPrm, inMember.Name);
                 if (inMember.Type != outMember.Type) {
-                    if (Helper.TypesCastable(inMember.Type, outMember.Type)) {
+                    if (Helper.TypesCastable(inMember.Type, outMember.Type) || Nullable.GetUnderlyingType(inMember.Type) != null) {
                         member = Expression.MakeUnary(ExpressionType.Convert, member, outMember.Type);
                     }
                     else {


### PR DESCRIPTION
## Change list

*Please provide briefly described change list which are you going to propose.*
 
## Types of changes

What types of changes are you proposing/introducing?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

When input and output types not equal and input properties equal to null,  because of trying convert null value,mapping gives an error message   ("Null object cannot be converted to a value type.").

 I blocked type conversion when input is nullable value type